### PR TITLE
Fix contractors

### DIFF
--- a/src/components/Display.js
+++ b/src/components/Display.js
@@ -336,10 +336,14 @@ export default class Display extends HTMLElement {
         contractorInfo.name = 'GFL';
         contractorInfo.url = 'http://gflusa.com/residential/detroit/';
         contractorInfo.phone = '(844) 464-3587';
-      } else {
+      } else if (value.data.next_pickups.trash.contractor === 'WM') {
         contractorInfo.name = 'WM';
         contractorInfo.url = 'http://www.advanceddisposal.com/mi/detroit/detroit-residential-collection';
-        contractorInfo.phone = ' (844) 233-8764';
+        contractorInfo.phone = '(844) 233-8764';
+      } else if (value.data.next_pickups.trash.contractor === 'Priority Waste') {
+        contractorInfo.name = 'Priority Waste';
+        contractorInfo.url = 'https://www.prioritywaste.com/cities-we-serve/detroit/';
+        contractorInfo.phone = '(855) 927-835';
       }
       dataParsing.content = `
             <p><strong>Provider:</strong> <a href="${contractorInfo.url}" target="_blank">${contractorInfo.name}</a> ${contractorInfo.phone}</p>


### PR DESCRIPTION
See #173 for details of the issue. Basically, we were defaulting to showing "WM" for all addresses across the city since we stopped using GFL a few weeks ago.

## This PR

- Add handling for Priority Waste as a contractor. Also, don't provide a default `else` case because it leads to scenarios where we show incorrect information when API data changes.

## Testing

Took a look at two different addresses served by WM and Priority Waste respectively and confirm the contractor info appears correctly.

WM:

![image](https://github.com/CityOfDetroit/local-services-lookup/assets/143553259/be0e6ee6-28fc-4025-b6f5-11edfb3eb8ed)

Priority Waste:

![image](https://github.com/CityOfDetroit/local-services-lookup/assets/143553259/40e6d383-ca9a-425e-a120-d52535bb98b1)
